### PR TITLE
Sctp fixes

### DIFF
--- a/sctp_streams_test.go
+++ b/sctp_streams_test.go
@@ -8,6 +8,11 @@ import (
 	"time"
 )
 
+const (
+	STREAM_TEST_CLIENTS = 128
+	STREAM_TEST_STREAMS = 11
+)
+
 func TestStreams(t *testing.T) {
 
 	r := rand.New(rand.NewSource(time.Now().UnixNano()))
@@ -15,7 +20,7 @@ func TestStreams(t *testing.T) {
 		const chars = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
 		result := make([]byte, strlen)
 		for i := range result {
-		result[i] = chars[r.Intn(len(chars))]
+			result[i] = chars[r.Intn(len(chars))]
 		}
 		return string(result)
 	}
@@ -68,7 +73,7 @@ func TestStreams(t *testing.T) {
 
 	wait := make(chan struct{})
 	i := 0
-	for ; i < 128; i++ {
+	for ; i < STREAM_TEST_CLIENTS; i++ {
 		go func(test int) {
 			defer func() { wait <- struct{}{} }()
 			conn, err := DialSCTP("sctp", nil, addr)
@@ -78,7 +83,7 @@ func TestStreams(t *testing.T) {
 			}
 			defer conn.Close()
 			conn.SubscribeEvents(SCTP_EVENT_DATA_IO)
-			for ppid := uint16(0); ppid < 11; ppid++ {
+			for ppid := uint16(0); ppid < STREAM_TEST_STREAMS; ppid++ {
 				info := &SndRcvInfo{
 					Stream: uint16(ppid),
 					PPID:   uint32(ppid),
@@ -127,4 +132,3 @@ func TestStreams(t *testing.T) {
 		}
 	}
 }
-

--- a/sctp_streams_test.go
+++ b/sctp_streams_test.go
@@ -1,0 +1,130 @@
+package sctp
+
+import (
+	"fmt"
+	"io"
+	"math/rand"
+	"testing"
+	"time"
+)
+
+func TestStreams(t *testing.T) {
+
+	r := rand.New(rand.NewSource(time.Now().UnixNano()))
+	randomStr := func(strlen int) string {
+		const chars = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+		result := make([]byte, strlen)
+		for i := range result {
+		result[i] = chars[r.Intn(len(chars))]
+		}
+		return string(result)
+	}
+
+	addr, _ := ResolveSCTPAddr("sctp", "127.0.0.1:0")
+	ln, err := ListenSCTP("sctp", addr)
+	if err != nil {
+		t.Fatalf("failed to listen: %v", err)
+	}
+	addr = ln.Addr().(*SCTPAddr)
+	t.Logf("Listen on %s", ln.Addr())
+
+	go func() {
+		for {
+			c, err := ln.Accept()
+			sconn := c.(*SCTPConn)
+			if err != nil {
+				t.Errorf("failed to accept: %v", err)
+				return
+			}
+			defer sconn.Close()
+
+			sconn.SubscribeEvents(SCTP_EVENT_DATA_IO)
+			go func() {
+				totalrcvd := 0
+				for {
+					buf := make([]byte, 512)
+					n, info, err := sconn.SCTPRead(buf)
+					if err != nil {
+						if err == io.EOF || err == io.ErrUnexpectedEOF {
+							if n == 0 {
+								break
+							}
+							t.Logf("EOF on server connection. Total bytes received: %d, bytes received: %d", totalrcvd, n)
+						} else {
+							t.Errorf("Server connection read err: %v. Total bytes received: %d, bytes received: %d", err, totalrcvd, n)
+							return
+						}
+					}
+					t.Logf("server read: info: %+v, payload: %s", info, string(buf[:n]))
+					n, err = sconn.SCTPWrite(buf[:n], info)
+					if err != nil {
+						t.Error(err)
+						return
+					}
+				}
+			}()
+		}
+	}()
+
+	wait := make(chan struct{})
+	i := 0
+	for ; i < 128; i++ {
+		go func(test int) {
+			defer func() { wait <- struct{}{} }()
+			conn, err := DialSCTP("sctp", nil, addr)
+			if err != nil {
+				t.Errorf("failed to dial address %s, test #%d: %v", addr.String(), test, err)
+				return
+			}
+			defer conn.Close()
+			conn.SubscribeEvents(SCTP_EVENT_DATA_IO)
+			for ppid := uint16(0); ppid < 11; ppid++ {
+				info := &SndRcvInfo{
+					Stream: uint16(ppid),
+					PPID:   uint32(ppid),
+				}
+				text := fmt.Sprintf("Test %s ***\n\t\t%d %d ***", randomStr(r.Intn(255)), test, ppid)
+				n, err := conn.SCTPWrite([]byte(text), info)
+				if err != nil {
+					t.Errorf("failed to write %s, len: %d, err: %v, bytes written: %d", text, len(text), err, n)
+					return
+				}
+				rn := 0
+				cn := 0
+				buf := make([]byte, 512)
+				for {
+					cn, info, err = conn.SCTPRead(buf[rn:])
+					if err != nil {
+						if err == io.EOF || err == io.ErrUnexpectedEOF {
+							rn += cn
+							break
+						}
+						t.Errorf("failed to read: %v", err)
+						return
+					}
+					if info.Stream != ppid {
+						t.Errorf("Mismatched PPIDs: %d != %d", info.Stream, ppid)
+						return
+					}
+					rn += cn
+					if rn >= n {
+						break
+					}
+				}
+				rtext := string(buf[:rn])
+				if rtext != text {
+					t.Fatalf("Mismatched payload: %s != %s", rtext, text)
+				}
+			}
+		}(i)
+	}
+	for ; i > 0; i-- {
+		select {
+		case <-wait:
+		case <-time.After(time.Second * 30):
+			close(wait)
+			t.Fatal("timed out")
+		}
+	}
+}
+


### PR DESCRIPTION
Go SCTP bug fixes:
    1) Fix to avoid returning negative read lenth on failed SCTP Reads (it breaks std Go buffered IO)
    2) Atomic access to internal SCTP Connection fd & connection close FD cleanup to prevent "double" fd closure which may affect another connection in multithreaded environments.