### PR TITLE
Support Link-Local IPv6 Addresses (add a Zone field)

### DIFF
--- a/example/sctp.go
+++ b/example/sctp.go
@@ -31,15 +31,17 @@ func main() {
 	var port = flag.Int("port", 0, "")
 	flag.Parse()
 
-	ips := []net.IP{}
+	ips := []net.IPAddr{}
 
 	for _, i := range strings.Split(*ip, ",") {
-		ips = append(ips, net.ParseIP(i))
+		if a, err := net.ResolveIPAddr("ip", i); err == nil {
+			ips = append(ips, *a)
+		}
 	}
 
 	addr := &sctp.SCTPAddr{
-		IP:   ips,
-		Port: *port,
+		IPAddrs: ips,
+		Port:    *port,
 	}
 
 	if *server {

--- a/sctp_linux.go
+++ b/sctp_linux.go
@@ -123,8 +123,8 @@ func ListenSCTP(net string, laddr *SCTPAddr) (*SCTPListener, error) {
 			if addr == nil {
 				return false
 			}
-			for _, ip := range addr.IP {
-				if ip.To4() == nil {
+			for _, ip := range addr.IPAddrs {
+				if ip.IP.To4() == nil {
 					return true
 				}
 			}
@@ -152,7 +152,7 @@ func ListenSCTP(net string, laddr *SCTPAddr) (*SCTPListener, error) {
 	if err != nil {
 		return nil, err
 	}
-	if laddr != nil && len(laddr.IP) != 0 {
+	if laddr != nil && len(laddr.IPAddrs) != 0 {
 		err := SCTPBind(sock, laddr, SCTP_BINDX_ADD_ADDR)
 		if err != nil {
 			return nil, err
@@ -185,8 +185,8 @@ func DialSCTP(net string, laddr, raddr *SCTPAddr) (*SCTPConn, error) {
 			if addr == nil {
 				return false
 			}
-			for _, ip := range addr.IP {
-				if ip.To4() == nil {
+			for _, ip := range addr.IPAddrs {
+				if ip.IP.To4() == nil {
 					return true
 				}
 			}

--- a/sctp_test.go
+++ b/sctp_test.go
@@ -18,16 +18,19 @@ type resolveSCTPAddrTest struct {
 }
 
 var resolveSCTPAddrTests = []resolveSCTPAddrTest{
-	{"sctp", "127.0.0.1:0", &SCTPAddr{IP: []net.IP{net.IPv4(127, 0, 0, 1)}, Port: 0}, nil},
-	{"sctp4", "127.0.0.1:65535", &SCTPAddr{IP: []net.IP{net.IPv4(127, 0, 0, 1)}, Port: 65535}, nil},
+	{"sctp", "127.0.0.1:0", &SCTPAddr{IPAddrs: []net.IPAddr{net.IPAddr{IP: net.IPv4(127, 0, 0, 1)}}, Port: 0}, nil},
+	{"sctp4", "127.0.0.1:65535", &SCTPAddr{IPAddrs: []net.IPAddr{net.IPAddr{IP: net.IPv4(127, 0, 0, 1)}}, Port: 65535}, nil},
 
-	{"sctp", "[::1]:0", &SCTPAddr{IP: []net.IP{net.ParseIP("::1")}, Port: 0}, nil},
-	{"sctp6", "[::1]:65535", &SCTPAddr{IP: []net.IP{net.ParseIP("::1")}, Port: 65535}, nil},
+	{"sctp", "[::1]:0", &SCTPAddr{IPAddrs: []net.IPAddr{net.IPAddr{IP: net.ParseIP("::1")}}, Port: 0}, nil},
+	{"sctp6", "[::1]:65535", &SCTPAddr{IPAddrs: []net.IPAddr{net.IPAddr{IP: net.ParseIP("::1")}}, Port: 65535}, nil},
+
+	{"sctp", "[fe80::1%eth0]:0", &SCTPAddr{IPAddrs: []net.IPAddr{net.IPAddr{IP: net.ParseIP("fe80::1"), Zone: "eth0"}}, Port: 0}, nil},
+	{"sctp6", "[fe80::1%eth0]:65535", &SCTPAddr{IPAddrs: []net.IPAddr{net.IPAddr{IP: net.ParseIP("fe80::1"), Zone: "eth0"}}, Port: 65535}, nil},
 
 	{"sctp", ":12345", &SCTPAddr{Port: 12345}, nil},
 
-	{"sctp", "127.0.0.1/10.0.0.1:0", &SCTPAddr{IP: []net.IP{net.IPv4(127, 0, 0, 1), net.IPv4(10, 0, 0, 1)}, Port: 0}, nil},
-	{"sctp4", "127.0.0.1/10.0.0.1:65535", &SCTPAddr{IP: []net.IP{net.IPv4(127, 0, 0, 1), net.IPv4(10, 0, 0, 1)}, Port: 65535}, nil},
+	{"sctp", "127.0.0.1/10.0.0.1:0", &SCTPAddr{IPAddrs: []net.IPAddr{net.IPAddr{IP: net.IPv4(127, 0, 0, 1)}, net.IPAddr{IP: net.IPv4(10, 0, 0, 1)}}, Port: 0}, nil},
+	{"sctp4", "127.0.0.1/10.0.0.1:65535", &SCTPAddr{IPAddrs: []net.IPAddr{net.IPAddr{IP: net.IPv4(127, 0, 0, 1)}, net.IPAddr{IP: net.IPv4(10, 0, 0, 1)}}, Port: 65535}, nil},
 }
 
 func TestSCTPAddrString(t *testing.T) {
@@ -59,7 +62,7 @@ var sctpListenerNameTests = []struct {
 	net   string
 	laddr *SCTPAddr
 }{
-	{"sctp4", &SCTPAddr{IP: []net.IP{net.IPv4(127, 0, 0, 1)}}},
+	{"sctp4", &SCTPAddr{IPAddrs: []net.IPAddr{net.IPAddr{IP: net.IPv4(127, 0, 0, 1)}}}},
 	{"sctp4", &SCTPAddr{}},
 	{"sctp4", nil},
 }


### PR DESCRIPTION
Fixes https://github.com/ishidawataru/sctp/issues/16

Includes tests to resolve addresses with a Zone specified (the part after the `%` sign in `[fe80::1%eth0]:65535`).

Important note: This changes the type and name of publicly exported fields in `SCTPAddr`:
```diff
 type SCTPAddr struct {
-	IP   []net.IP
-	Port int
+	IPAddrs []net.IPAddr
+	Port    int
 }
```

Each `net.IPAddr` then contains `IP` and `Zone` fields, with the latter being relevant for link-local IPv6 addresses.