### PR TITLE
Add support for SocketOptions

### DIFF
--- a/sctp.go
+++ b/sctp.go
@@ -709,3 +709,21 @@ func (c *SCTPSndRcvInfoWrappedConn) SetReadBuffer(bytes int) error {
 func (c *SCTPSndRcvInfoWrappedConn) GetReadBuffer() (int, error) {
 	return c.conn.GetReadBuffer()
 }
+
+// SocketConfig contains options for the SCTP socket.
+type SocketConfig struct {
+	// If Control is not nil it is called after the socket is created but before
+	// it is bound or connected.
+	Control func(network, address string, c syscall.RawConn) error
+
+	// InitMsg is the options to send in the initial SCTP message
+	InitMsg InitMsg
+}
+
+func (cfg *SocketConfig) Listen(net string, laddr *SCTPAddr) (*SCTPListener, error) {
+	return listenSCTPExtConfig(net, laddr, cfg.InitMsg, cfg.Control)
+}
+
+func (cfg *SocketConfig) Dial(net string, laddr, raddr *SCTPAddr) (*SCTPConn, error) {
+	return dialSCTPExtConfig(net, laddr, raddr, cfg.InitMsg, cfg.Control)
+}

--- a/sctp_unsupported.go
+++ b/sctp_unsupported.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"net"
 	"runtime"
+	"syscall"
 )
 
 var ErrUnsupported = errors.New("SCTP is unsupported on " + runtime.GOOS + "/" + runtime.GOARCH)
@@ -68,6 +69,10 @@ func ListenSCTPExt(net string, laddr *SCTPAddr, options InitMsg) (*SCTPListener,
 	return nil, ErrUnsupported
 }
 
+func listenSCTPExtConfig(network string, laddr *SCTPAddr, options InitMsg, control func(network, address string, c syscall.RawConn) error) (*SCTPListener, error) {
+	return nil, ErrUnsupported
+}
+
 func (ln *SCTPListener) Accept() (net.Conn, error) {
 	return nil, ErrUnsupported
 }
@@ -85,5 +90,9 @@ func DialSCTP(net string, laddr, raddr *SCTPAddr) (*SCTPConn, error) {
 }
 
 func DialSCTPExt(network string, laddr, raddr *SCTPAddr, options InitMsg) (*SCTPConn, error) {
+	return nil, ErrUnsupported
+}
+
+func dialSCTPExtConfig(network string, laddr, raddr *SCTPAddr, options InitMsg, control func(network, address string, c syscall.RawConn) error) (*SCTPConn, error) {
 	return nil, ErrUnsupported
 }


### PR DESCRIPTION
Signed-off-by: Spike Curtis <spike@tigera.io>

I'm finding myself needing to set `SO_REUSEADDR` and `SO_REUSEPORT` in my application.  WDYT of this way of passing them to the library?