### PR TITLE
support goarch mips64le architecture.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ script:
  - GOOS=linux   GOARCH=arm     go build .
  - GOOS=linux   GOARCH=arm64   go build .
  - GOOS=linux   GOARCH=ppc64le go build .
+ - GOOS=linux   GOARCH=mips64le go build .
  - (go version | grep go1.6 > /dev/null) || GOOS=linux   GOARCH=s390x   go build .
 # can be compiled but not functional:
  - GOOS=linux   GOARCH=386     go build .


### PR DESCRIPTION
hello，I am going to submit mips64le architecture，The main reasons for adding support for mips64le architecture are:
1、The mips64le architecture is also the mainstream cpu architecture (amd64, arm64), which is used by many users;
2、Golang supports cross compilation, and mips64le is officially supported.
3、This project is an underlying dependency library of the kubernetes project [k/k](https://github.com/kubernetes/kubernetes), so this patch needs to be submitted.
Therefore, I hope that the release package also supports the mips64le architecture, which is convenient for more users.
Signed-off-by: houfangdong houfangdong@loongson.com