### PR TITLE
Adds fix for s390x in getsockopt()

### DIFF
--- a/sctp_linux.go
+++ b/sctp_linux.go
@@ -22,6 +22,7 @@ import (
 	"sync/atomic"
 	"syscall"
 	"unsafe"
+	"runtime"
 )
 
 func setsockopt(fd int, optname, optval, optlen uintptr) (uintptr, uintptr, error) {
@@ -40,6 +41,9 @@ func setsockopt(fd int, optname, optval, optlen uintptr) (uintptr, uintptr, erro
 }
 
 func getsockopt(fd int, optname, optval, optlen uintptr) (uintptr, uintptr, error) {
+	if runtime.GOARCH == "s390x" {
+		optlen = uintptr(unsafe.Pointer(&optlen))
+	}
 	// FIXME: syscall.SYS_GETSOCKOPT is undefined on 386
 	r0, r1, errno := syscall.Syscall6(syscall.SYS_GETSOCKOPT,
 		uintptr(fd),


### PR DESCRIPTION
When tried the `go test` and [example](https://github.com/ishidawataru/sctp#examples) on s390x, observed following errors as it is not able to listen on specified address and returns nil.
Error:
```
panic: interface conversion: net.Addr is nil, not *sctp.SCTPAddr [recovered]
panic: interface conversion: net.Addr is nil, not *sctp.SCTPAddr
```
Example:
```
# ./example -server -port 1000 -ip localhost
2023/03/31 01:23:08 Resolved address 'localhost' to 127.0.0.1
2023/03/31 01:23:08 raw addr: [0 2 3 232 127 0 0 1 0 0 0 0 0 0 0 0]
2023/03/31 01:23:08 Listen on %!s(<nil>)
```

It appears that on s390x, the getsockopt() function is encountering an issue while passing the optlen argument. This is because the syscall.Syscall6 funtion calls syscall.socketcall function on s390x by default which expects some different argument than Syscall6 function.

This PR is intended to address this issue observed on s390x. 
Thanks