### PR TITLE
Fix NRE Panic in dialSCTPExtConfig and listenSCTPExtConfig when control is used

### DIFF
--- a/sctp_linux.go
+++ b/sctp_linux.go
@@ -200,7 +200,11 @@ func listenSCTPExtConfig(network string, laddr *SCTPAddr, options InitMsg, contr
 	}
 	if control != nil {
 		rc := rawConn{sockfd: sock}
-		if err = control(network, laddr.String(), rc); err != nil {
+		var localAddressString string
+		if laddr != nil {
+			localAddressString = laddr.String()
+		}
+		if err = control(network, localAddressString, rc); err != nil {
 			return nil, err
 		}
 	}

--- a/sctp_linux.go
+++ b/sctp_linux.go
@@ -1,4 +1,6 @@
+//go:build linux && !386
 // +build linux,!386
+
 // Copyright 2019 Wataru Ishida. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -19,10 +21,10 @@ package sctp
 import (
 	"io"
 	"net"
+	"runtime"
 	"sync/atomic"
 	"syscall"
 	"unsafe"
-	"runtime"
 )
 
 func setsockopt(fd int, optname, optval, optlen uintptr) (uintptr, uintptr, error) {
@@ -279,7 +281,11 @@ func dialSCTPExtConfig(network string, laddr, raddr *SCTPAddr, options InitMsg, 
 	}
 	if control != nil {
 		rc := rawConn{sockfd: sock}
-		if err = control(network, laddr.String(), rc); err != nil {
+		var localAddressString string
+		if laddr != nil {
+			localAddressString = laddr.String()
+		}
+		if err = control(network, localAddressString, rc); err != nil {
 			return nil, err
 		}
 	}

--- a/sctp_linux_test.go
+++ b/sctp_linux_test.go
@@ -1,0 +1,53 @@
+//go:build linux && !386
+// +build linux,!386
+
+// Copyright 2019 Wataru Ishida. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sctp
+
+import (
+	"net"
+	"syscall"
+	"testing"
+)
+
+func TestUseControlFuncWithoutLocalAddress(t *testing.T) {
+	network := "sctp"
+	raddr := &SCTPAddr{IPAddrs: []net.IPAddr{net.IPAddr{IP: net.IPv4(127, 0, 0, 1)}}}
+	initMsg := InitMsg{
+		NumOstreams:    0,
+		MaxInstreams:   0,
+		MaxAttempts:    0,
+		MaxInitTimeout: 0,
+	}
+	customControlFunc := func(networkFunc, address string, c syscall.RawConn) error {
+		if network != networkFunc {
+			t.Fatalf("network invalid: %s", networkFunc)
+		}
+		if address != "" {
+			t.Fatalf("address not empty: %s", address)
+		}
+		if c == nil {
+			t.Fatal("RawConn is nil")
+		}
+		return nil
+	}
+	conn, err := dialSCTPExtConfig(network, nil, raddr, initMsg, customControlFunc)
+	if err != nil {
+		t.Fatalf("failed to dial SCTP connection due to: %v", err)
+	}
+	conn.Close()
+}


### PR DESCRIPTION
## Description  
This PR fixes a nil reference panic that occurs in `dialSCTPExtConfig` and `listenSCTPExtConfig` when the `control` function is passed and `laddr` is `nil` (SCTP use without SCTP_SOCKOPT_BINDX_ADD).  
The issue was caused by calling `laddr.String()` without checking for `nil`.  

## Panic Stacktrace:
```
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
	panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x53be03]

goroutine 6 [running]:
testing.tRunner.func1.2({0x55b2a0, 0x695fc0})
	/usr/local/go/src/testing/testing.go:1526 +0x24e
testing.tRunner.func1()
	/usr/local/go/src/testing/testing.go:1529 +0x39f
panic({0x55b2a0, 0x695fc0})
	/usr/local/go/src/runtime/panic.go:884 +0x213
github.com/ishidawataru/sctp.(*SCTPAddr).String(0x0)

```

## Fix  
Added a `nil` check before accessing `laddr.String()` in both functions. Pass an empty string to the control function:  

```go
var localAddressString string  
if laddr != nil {  
    localAddressString = laddr.String()  
}
if err = control(network, localAddressString, rc); err != nil {
    return nil, err
}
```