### PR TITLE
Fixing SndRcvInfo codec

### DIFF
--- a/sctp.go
+++ b/sctp.go
@@ -213,6 +213,17 @@ func toBuf(v interface{}) []byte {
 	return buf.Bytes()
 }
 
+func toNetworkByteOrderBuf(v interface{}) []byte {
+	var buf bytes.Buffer
+	binary.Write(&buf, binary.BigEndian, v)
+	return buf.Bytes()
+}
+
+func fromNetworkByteOrderBuf(v interface{}, src []byte) (err error) {
+	buf := bytes.NewBuffer(src)
+	return binary.Read(buf, binary.BigEndian, v)
+}
+
 func htons(h uint16) uint16 {
 	if nativeEndian == binary.LittleEndian {
 		return (h << 8 & 0xff00) | (h >> 8 & 0xff)

--- a/sctp_linux.go
+++ b/sctp_linux.go
@@ -19,6 +19,7 @@
 package sctp
 
 import (
+	"fmt"
 	"io"
 	"net"
 	"runtime"
@@ -80,7 +81,7 @@ func (r rawConn) Write(f func(fd uintptr) (done bool)) error {
 func (c *SCTPConn) SCTPWrite(b []byte, info *SndRcvInfo) (int, error) {
 	var cbuf []byte
 	if info != nil {
-		cmsgBuf := toBuf(info)
+		cmsgBuf := toNetworkByteOrderBuf(info)
 		hdr := &syscall.Cmsghdr{
 			Level: syscall.IPPROTO_SCTP,
 			Type:  SCTP_CMSG_SNDRCV,
@@ -103,7 +104,11 @@ func parseSndRcvInfo(b []byte) (*SndRcvInfo, error) {
 		if m.Header.Level == syscall.IPPROTO_SCTP {
 			switch m.Header.Type {
 			case SCTP_CMSG_SNDRCV:
-				return (*SndRcvInfo)(unsafe.Pointer(&m.Data[0])), nil
+				var dst SndRcvInfo
+				if err := fromNetworkByteOrderBuf(&dst, m.Data); err != nil {
+					return nil, fmt.Errorf("failed to parse SndRcvInfo: %v", err)
+				}
+				return &dst, nil
 			}
 		}
 	}


### PR DESCRIPTION
As described in #66 the PPID (and probably more) was encoded/decoded wrongly on a little-endian system (e.g. x86).

[RFC 4960](https://www.rfc-editor.org/rfc/rfc4960#section-3) says: "All integer fields in an SCTP packet MUST be transmitted in network byte order, unless otherwise stated."

Then:
- for encoding the use of `toBuf` was wrong, since it uses the `nativeEndian` - on x86 that is `binary.LittleEndian`, while we want to write it on the wire as `binary.BigEndian`
- for decoding the direct mapping of unsafe pointer is wrong, since there is no transformation made to the `nativeEndian`, hence would produce bad results on `binary.LittleEndian` systems

I guess this is a general problem and most likely `toBuf` should be retired entirely. I am not a big fan of using unsafe pointers, so my proposal would be to take it out as much as possible, or even entirely. The small optimizations are not worth the risk of bugs, IMHO. But anyway, to get this patch hopefully merged quickly, I have only did the minimal fix for fixing the PPID issues.

P.S. The bug was symmetrical (both for encode and decode) and only visible on little-endian systems.