### PR TITLE
Implement SyscallConn() method for SCTPConn to expose syscall.RawConn (#76)

### DIFF
--- a/sctp_linux.go
+++ b/sctp_linux.go
@@ -77,6 +77,14 @@ func (r rawConn) Write(f func(fd uintptr) (done bool)) error {
 	panic("not implemented")
 }
 
+func (c *SCTPConn) SyscallConn() (syscall.RawConn, error) {
+	fd := c.fd()
+	if fd < 0 {
+		return nil, syscall.EINVAL
+	}
+	return &rawConn{sockfd: int(fd)}, nil
+}
+
 func (c *SCTPConn) SCTPWrite(b []byte, info *SndRcvInfo) (int, error) {
 	var cbuf []byte
 	if info != nil {


### PR DESCRIPTION
This PR adds a `SyscallConn()` method to the `SCTPConn` type, as discussed in [[Issue #76](https://github.com/ishidawataru/sctp/issues/76)](https://github.com/ishidawataru/sctp/issues/76).

This change allows users to access the underlying file descriptor via the `syscall.RawConn` interface, similar to what's available in standard library types like `net.TCPConn`.

#### 🧪 Testing:

* Manual testing performed to ensure `SyscallConn()` returns a valid raw connection
* No existing behavior is affected

Let me know if you'd like tests or changes to how `rawConn` is structured.
