### PR TITLE
Implement SyscallConn() method for SCTPListener to expose syscall.RawConn (#76)

### DIFF
--- a/sctp_linux.go
+++ b/sctp_linux.go
@@ -269,6 +269,14 @@ func (ln *SCTPListener) Close() error {
 	return syscall.Close(ln.fd)
 }
 
+func (ln *SCTPListener) SyscallConn() (syscall.RawConn, error) {
+	fd := ln.fd
+	if fd < 0 {
+		return nil, syscall.EINVAL
+	}
+	return &rawConn{sockfd: int(fd)}, nil
+}
+
 // DialSCTP - bind socket to laddr (if given) and connect to raddr
 func DialSCTP(net string, laddr, raddr *SCTPAddr) (*SCTPConn, error) {
 	return DialSCTPExt(net, laddr, raddr, InitMsg{NumOstreams: SCTP_MAX_STREAM})

--- a/sctp_linux_test.go
+++ b/sctp_linux_test.go
@@ -104,17 +104,27 @@ func validationControlFunc(t *testing.T, network string) func(networkFunc, addre
 func TestSyscallConn(t *testing.T) {
 	network := "sctp"
 	addr := &SCTPAddr{IPAddrs: []net.IPAddr{{IP: net.IPv4(127, 0, 0, 1)}}, Port: 54321}
-	_, err := ListenSCTP(network, addr)
+	listener, err := ListenSCTP(network, addr)
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer listener.Close()
+
+    raw, err := listener.SyscallConn()
+    if err != nil {
+        t.Fatalf("Expected no error, got %v", err)
+    }
+    if raw == nil {
+        t.Fatalf("Expected non-nil RawConn, got nil")
+    }
+
 	conn, err := DialSCTP(network, nil, addr)
 	if err != nil {
 		t.Fatalf("Failed to create SCTP connection: %v", err)
 	}
 	defer conn.Close()
 
-	raw, err := conn.SyscallConn()
+	raw, err = conn.SyscallConn()
 	if err != nil {
 		t.Fatalf("Expected no error, got %v", err)
 	}


### PR DESCRIPTION
This PR adds a SyscallConn() method to the SCTPListener type, similar to [https://github.com/ishidawataru/sctp/issues/76](https://github.com/ishidawataru/sctp/issues/76).

This change allows users to access the underlying file descriptor via the syscall.RawConn interface, similar to what's available in standard library types like net.TCPListener

🧪 Testing:
Manual testing performed to ensure SyscallConn() returns a valid raw connection
No existing behavior is affected

Let me know if you'd like tests or changes to how rawConn is structured.